### PR TITLE
Fix navigation: update links to home page and LinkedIn URL

### DIFF
--- a/Material UI/src/loopix/components/Footer.tsx
+++ b/Material UI/src/loopix/components/Footer.tsx
@@ -27,7 +27,7 @@ export default function Footer() {
             <Link underline="none" color="text.primary" href="/#contact">Contact</Link>
           </Stack>
           <Stack direction="row" spacing={1.5}>
-            <Link aria-label="LinkedIn" href="https://www.linkedin.com" target="_blank" rel="noopener">
+            <Link aria-label="LinkedIn" href="https://www.linkedin.com/in/ajith-sabu-885b79382/" target="_blank" rel="noopener">
               <LinkedInIcon />
             </Link>
             <Link aria-label="Email" href="mailto:loopixsolutionssg@gmail.com">

--- a/Material UI/src/loopix/components/Footer.tsx
+++ b/Material UI/src/loopix/components/Footer.tsx
@@ -20,11 +20,11 @@ export default function Footer() {
             </Box>
           </Box>
           <Stack direction="row" spacing={2}>
-            <Link underline="none" color="text.primary" href="#">Home</Link>
-            <Link underline="none" color="text.primary" href="#about">About</Link>
-            <Link underline="none" color="text.primary" href="#services">Services</Link>
-            <Link underline="none" color="text.primary" href="#portfolio">Portfolio</Link>
-            <Link underline="none" color="text.primary" href="#contact">Contact</Link>
+            <Link underline="none" color="text.primary" href="/">Home</Link>
+            <Link underline="none" color="text.primary" href="/#about">About</Link>
+            <Link underline="none" color="text.primary" href="/#services">Services</Link>
+            <Link underline="none" color="text.primary" href="/#portfolio">Portfolio</Link>
+            <Link underline="none" color="text.primary" href="/#contact">Contact</Link>
           </Stack>
           <Stack direction="row" spacing={1.5}>
             <Link aria-label="LinkedIn" href="https://www.linkedin.com" target="_blank" rel="noopener">

--- a/Material UI/src/loopix/components/Footer.tsx
+++ b/Material UI/src/loopix/components/Footer.tsx
@@ -27,7 +27,7 @@ export default function Footer() {
             <Link underline="none" color="text.primary" href="/#contact">Contact</Link>
           </Stack>
           <Stack direction="row" spacing={1.5}>
-            <Link aria-label="LinkedIn" href="https://www.linkedin.com/in/ajith-sabu-885b79382/" target="_blank" rel="noopener">
+            <Link aria-label="LinkedIn" href="https://www.linkedin.com/in/loopix-solutions-885b79382/" target="_blank" rel="noopener">
               <LinkedInIcon />
             </Link>
             <Link aria-label="Email" href="mailto:loopixsolutionssg@gmail.com">

--- a/Material UI/src/loopix/components/Header.tsx
+++ b/Material UI/src/loopix/components/Header.tsx
@@ -25,22 +25,22 @@ export default function Header() {
           </Box>
         </Box>
         <Box sx={{ display: { xs: "none", sm: "flex" }, alignItems: "center", gap: 2 }}>
-          <Link underline="none" color="text.primary" href="#about" sx={{ fontWeight: 500 }}>
+          <Link underline="none" color="text.primary" href="/#about" sx={{ fontWeight: 500 }}>
             About
           </Link>
-          <Link underline="none" color="text.primary" href="#services" sx={{ fontWeight: 500 }}>
+          <Link underline="none" color="text.primary" href="/#services" sx={{ fontWeight: 500 }}>
             Services
           </Link>
-          <Link underline="none" color="text.primary" href="#industries" sx={{ fontWeight: 500 }}>
+          <Link underline="none" color="text.primary" href="/#industries" sx={{ fontWeight: 500 }}>
             Industries
           </Link>
-          <Link underline="none" color="text.primary" href="#portfolio" sx={{ fontWeight: 500 }}>
+          <Link underline="none" color="text.primary" href="/#portfolio" sx={{ fontWeight: 500 }}>
             Portfolio
           </Link>
-          <Link underline="none" color="text.primary" href="#contact" sx={{ fontWeight: 500 }}>
+          <Link underline="none" color="text.primary" href="/#contact" sx={{ fontWeight: 500 }}>
             Contact
           </Link>
-          <Button variant="contained" color="primary" href="#contact" sx={{ borderRadius: 2, px: 2.5 }}>
+          <Button variant="contained" color="primary" href="/#contact" sx={{ borderRadius: 2, px: 2.5 }}>
             Get Started
           </Button>
         </Box>

--- a/Material UI/src/loopix/components/Header.tsx
+++ b/Material UI/src/loopix/components/Header.tsx
@@ -10,7 +10,7 @@ export default function Header() {
   return (
     <AppBar position="sticky" color="inherit" elevation={0} sx={{ borderBottom: 1, borderColor: "divider", bgcolor: "common.white" }}>
       <Toolbar sx={{ maxWidth: 1200, mx: "auto", width: "100%", py: 1 }}>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexGrow: 1 }}>
+        <Link underline="none" color="inherit" href="/" sx={{ display: "flex", alignItems: "center", gap: 1, flexGrow: 1, cursor: "pointer" }}>
           <Box className="logo-badge" sx={{ display: "inline-flex", alignItems: "center", justifyContent: "center", mr: 1 }}>
             {/* Smart image with fallback */}
             <img src="https://cdn.builder.io/api/v1/image/assets%2Ff412044fdee74b4da312f40781fe7702%2F452151f601bf4767af584aa45770b5a1?format=webp&width=800" alt="Loopix Solutions" style={{ width: 36, height: 36, objectFit: 'contain' }} onError={(e)=>{ (e.target as HTMLImageElement).src='data:image/svg+xml;utf8,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2736%27 height=%2736%27%3E%3Crect width=%2736%27 height=%2736%27 fill=%27%2300A6C8%27 rx=%278%27/%3E%3Ctext x=%2718%27 y=%2722%27 text-anchor=%27middle%27 font-size=%2714%27 fill=%27%23fff%27 font-family=%27Inter,Arial,sans-serif%27%3EL%3C/text%3E%3C/svg%3E'}} />
@@ -23,7 +23,7 @@ export default function Header() {
               Web • Automation • Dashboards • Cloud • Integrations • Security • Support
             </Typography>
           </Box>
-        </Box>
+        </Link>
         <Box sx={{ display: { xs: "none", sm: "flex" }, alignItems: "center", gap: 2 }}>
           <Link underline="none" color="text.primary" href="/#about" sx={{ fontWeight: 500 }}>
             About

--- a/Material UI/src/loopix/components/Portfolio.tsx
+++ b/Material UI/src/loopix/components/Portfolio.tsx
@@ -107,7 +107,7 @@ export default function Portfolio() {
         </Typography>
         <Grid container spacing={3}>
           <Grid item xs={12} md={4}>
-            <Paper elevation={0} className="glass-card" sx={{ p: 2, height: { md: 560 }, overflow: { xs: 'visible', md: 'hidden' } }}>
+            <Paper elevation={0} className="glass-card" sx={{ p: 2, height: { md: 266 }, overflow: { xs: 'visible', md: 'hidden' } }}>
               <Typography variant="subtitle1" sx={{ fontWeight: 700, mb: 1 }}>
                 Projects
               </Typography>

--- a/Material UI/src/loopix/components/Portfolio.tsx
+++ b/Material UI/src/loopix/components/Portfolio.tsx
@@ -124,7 +124,7 @@ export default function Portfolio() {
                           setSelectedId(p.id);
                         }}
                         selected={p.id === selectedId}
-                        sx={{ alignItems: 'flex-start', gap: 2, borderRadius: 1 }}
+                        sx={{ alignItems: 'flex-start', gap: 2, borderRadius: 1, p: '8px 69px 8px 16px', mr: '1px' }}
                       >
                         <Avatar variant="rounded" src={p.images[0]} alt={p.title} sx={{ width: 64, height: 64 }} imgProps={{ onError:(e:any)=>{ e.currentTarget.src='data:image/svg+xml;utf8,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2764%27 height=%2764%27%3E%3Crect width=%2764%27 height=%2764%27 fill=%27%23e6f7fb%27 rx=%279%27/%3E%3Ctext x=%2732%27 y=%2738%27 text-anchor=%27middle%27 font-size=%2710%27 fill=%27%23008aa0%27 font-family=%27Inter,Arial,sans-serif%27%3EImg%3C/text%3E%3C/svg%3E' } , crossOrigin: 'anonymous'}} />
                         <ListItemText

--- a/Material UI/src/loopix/pages/ProjectClinicIntake.tsx
+++ b/Material UI/src/loopix/pages/ProjectClinicIntake.tsx
@@ -43,7 +43,7 @@ export default function ProjectClinicIntake(){
       <main>
         <Container maxWidth="lg" sx={{ py: { xs: 4, md: 8 } }}>
           <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
-            <Button component="a" href="/portfolio" startIcon={<ArrowBackIcon />} variant="outlined">
+            <Button component="a" href="/" startIcon={<ArrowBackIcon />} variant="outlined">
               Back to Portfolio
             </Button>
           </Box>

--- a/Material UI/src/loopix/pages/ProjectRestaurant.tsx
+++ b/Material UI/src/loopix/pages/ProjectRestaurant.tsx
@@ -42,7 +42,7 @@ export default function ProjectRestaurant(){
       <main>
         <Container maxWidth="lg" sx={{ py: { xs: 4, md: 8 } }}>
           <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
-            <Button component="a" href="/portfolio" startIcon={<ArrowBackIcon />} variant="outlined">
+            <Button component="a" href="/" startIcon={<ArrowBackIcon />} variant="outlined">
               Back to Portfolio
             </Button>
           </Box>

--- a/Material UI/src/loopix/pages/ProjectStartupDashboard.tsx
+++ b/Material UI/src/loopix/pages/ProjectStartupDashboard.tsx
@@ -42,7 +42,7 @@ export default function ProjectStartupDashboard(){
       <main>
         <Container maxWidth="lg" sx={{ py: { xs: 4, md: 8 } }}>
           <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
-            <Button component="a" href="/portfolio" startIcon={<ArrowBackIcon />} variant="outlined">
+            <Button component="a" href="/" startIcon={<ArrowBackIcon />} variant="outlined">
               Back to Portfolio
             </Button>
           </Box>

--- a/Material UI/src/loopix/pages/ProjectTuitionCentre.tsx
+++ b/Material UI/src/loopix/pages/ProjectTuitionCentre.tsx
@@ -42,7 +42,7 @@ export default function ProjectTuitionCentre(){
       <main>
         <Container maxWidth="lg" sx={{ py: { xs: 4, md: 8 } }}>
           <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
-            <Button component="a" href="/portfolio" startIcon={<ArrowBackIcon />} variant="outlined">
+            <Button component="a" href="/" startIcon={<ArrowBackIcon />} variant="outlined">
               Back to Portfolio
             </Button>
           </Box>


### PR DESCRIPTION
## Purpose
The user encountered navigation issues where clicking "Back to Portfolio" buttons from individual project pages would only take them to `/portfolio` instead of the home page (`/`). They also wanted the logo to be clickable and navigate to the home page from any location. Additionally, they requested updating the LinkedIn URL to point to the correct Loopix Solutions profile.

## Code changes
- **Header component**: Made the logo clickable by wrapping it in a Link component that navigates to home page (`/`)
- **Navigation links**: Updated all header and footer navigation links to use absolute paths (`/#about`, `/#services`, etc.) instead of hash-only anchors
- **Project pages**: Changed "Back to Portfolio" buttons in all project detail pages to navigate to home page (`/`) instead of `/portfolio`
- **LinkedIn URL**: Updated LinkedIn link in footer to point to the correct Loopix Solutions profile
- **Portfolio component**: Minor styling adjustments to list item padding and heightTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/25789a6cf8b3448c834eddfd71ab1571/zen-realm)

👀 [Preview Link](https://25789a6cf8b3448c834eddfd71ab1571-zen-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>25789a6cf8b3448c834eddfd71ab1571</projectId>-->
<!--<branchName>zen-realm</branchName>-->